### PR TITLE
make libnetpbm import work on Ubuntu/Debian (upstream #1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@
 CTL_LANG=1
 
 
-CFLAGS = -Wall -Wno-unused-function -Wno-unused-but-set-variable
+CFLAGS = -Wall -Wno-unused-function -Wno-unused-but-set-variable -I/usr/include/netpbm
 LDFLAGS =
 LDLIBS = -ltiff -ljpeg -lnetpbm -lz -lm
 

--- a/tumble_pbm.c
+++ b/tumble_pbm.c
@@ -28,7 +28,8 @@
 #include <stdlib.h>
 #include <strings.h>  /* strcasecmp() is a BSDism */
 
-#include <netpbm/pbm.h>
+#define HAVE_BOOL 1
+#include <pbm.h>
 /*
  * pbm_readpbmrow_packed always uses big-endian bit ordering.
  * On little-endian processors (such as the x86), we want little-endian


### PR DESCRIPTION
Deal with Debian/Ubuntu's version of libnetpbm10-dev.

See upstream issue #1